### PR TITLE
Fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ This will:
 
 ```
 Options:
-  --provider <provider>    LLM model to use (default: "claude-sonnet-3.7-latest") (currently only claude models are supported)
-  -o, --output <file>      Output file name (defaults to <repo-name>.rules.mdc)
-  --guidelines <file>      Path to cursor rules guidelines file (default: "./cursorrules-guidelines.md")
+  --provider <provider>    LLM model to use (default: "claude-sonnet-4-5-20250929")
   --description <text>     Description of what should be rulefied
   --rule-type <type>       Type of rule to generate (auto, manual, agent, always)
+  --tokenizer <tokenizer>  Tokenizer used to count tokens (default: "p50k_base")
+  --chunk-size <size>      Chunk size for the repository to be processed in one go (default: 100000)
   -h, --help               display help for command
 ```
 
@@ -149,4 +149,3 @@ This project is inspired by and builds upon the work of:
 - [cursor-custom-agents-rules-generator](https://github.com/bmadcode/cursor-custom-agents-rules-generator) - best practices for Cursor custom agents and rules generator
 
 We're grateful to these projects for their contributions to the developer tooling ecosystem.
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.20.0",
+        "@anthropic-ai/sdk": "^0.69.0",
         "commander": "^13.1.0",
         "js-tiktoken": "^1.0.19",
         "picocolors": "^1.1.0",
@@ -23,7 +23,7 @@
         "@typescript-eslint/eslint-plugin": "^8.27.0",
         "@typescript-eslint/parser": "^8.27.0",
         "eslint": "^8.56.0",
-        "rimraf": "^5.0.5",
+        "rimraf": "^6.1.0",
         "typescript": "^5.3.3",
         "vitest": "^3.1.1"
       },
@@ -32,35 +32,33 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.20.9",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.20.9.tgz",
-      "integrity": "sha512-Lq74+DhiEQO6F9/gdVOLmHx57pX45ebK2Q/zH14xYe1157a7QeUVknRqIp0Jz5gQI01o7NKbuv9Dag2uQsLjDg==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.69.0.tgz",
+      "integrity": "sha512-L92d2q47BSq+7slUqHBL1d2DwloulZotYGCTDt9AYRtPmYF+iK6rnwq9JaZwPPJgk+LenbcbQ/nj6gfaDFsl9w==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7",
-        "web-streams-polyfill": "^3.2.1"
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
-      "version": "18.19.86",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.86.tgz",
-      "integrity": "sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==",
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
+      "engines": {
+        "node": ">=6.9.0"
       }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/@clack/core": {
       "version": "0.4.2",
@@ -657,6 +655,29 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -676,9 +697,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -689,9 +710,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -702,9 +723,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1086,17 +1107,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.40.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.0.tgz",
@@ -1439,19 +1449,10 @@
       "version": "20.17.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
       "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/parse-path": {
@@ -2004,18 +2005,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -2071,18 +2060,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2159,12 +2136,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2420,18 +2391,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
@@ -2547,15 +2506,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -2681,21 +2631,6 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2953,15 +2888,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/eventsource": {
@@ -3333,50 +3259,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
-    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3507,21 +3389,24 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "path-scurry": "^2.0.0"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3538,6 +3423,22 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -3618,21 +3519,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -3668,15 +3554,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -3924,19 +3801,19 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
+      "engines": {
+        "node": "20 || >=22"
+      },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/js-tiktoken": {
@@ -3976,6 +3853,19 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -4104,11 +3994,14 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.17",
@@ -4176,27 +4069,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -4304,45 +4176,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
@@ -4559,17 +4392,17 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -4936,16 +4769,20 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.0.tgz",
+      "integrity": "sha512-DxdlA1bdNzkZK7JiNWH+BAx1x4tEJWoTofIopFo6qWUU94jYrFZ0ubY05TqH3nWPJ1nKa1JWVFDINZ3fnrle/A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "glob": "^10.3.7"
+        "glob": "^11.0.3",
+        "package-json-from-dist": "^1.0.1"
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5373,9 +5210,9 @@
       }
     },
     "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5386,9 +5223,9 @@
       }
     },
     "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5649,12 +5486,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/tree-sitter-wasms": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.12.tgz",
@@ -5663,6 +5494,12 @@
       "dependencies": {
         "tree-sitter-wasms": "^0.1.11"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
@@ -5769,6 +5606,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -6022,36 +5860,11 @@
         }
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/web-tree-sitter": {
       "version": "0.24.7",
       "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.7.tgz",
       "integrity": "sha512-CdC/TqVFbXqR+C51v38hv6wOPatKEUGxa39scAeFSm98wIhZxAYonhRQPSMmfZ2w7JDI0zQDdzdmgtNk06/krQ==",
       "license": "MIT"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6251,18 +6064,18 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@types/node": "^20.11.5",
         "@typescript-eslint/eslint-plugin": "^8.27.0",
-        "@typescript-eslint/parser": "^7.14.0",
+        "@typescript-eslint/parser": "^8.27.0",
         "eslint": "^8.56.0",
         "rimraf": "^5.0.5",
         "typescript": "^5.3.3",
@@ -562,9 +562,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -612,9 +612,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1491,46 +1491,42 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
-      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.4.tgz",
+      "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.18.0",
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/typescript-estree": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0",
+        "@typescript-eslint/scope-manager": "8.46.4",
+        "@typescript-eslint/types": "8.46.4",
+        "@typescript-eslint/typescript-estree": "8.46.4",
+        "@typescript-eslint/visitor-keys": "8.46.4",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
-      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.4.tgz",
+      "integrity": "sha512-tMDbLGXb1wC+McN1M6QeDx7P7c0UWO5z9CXqp7J8E+xGcJuUuevWKxuG8j41FoweS3+L41SkyKKkia16jpX7CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0"
+        "@typescript-eslint/types": "8.46.4",
+        "@typescript-eslint/visitor-keys": "8.46.4"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1538,21 +1534,56 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
-      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.4.tgz",
+      "integrity": "sha512-/++5CYLQqsO9HFGLI7APrxBJYo+5OCMpViuhV8q5/Qa3o5mMrF//eQHks+PXcsAVaLdn817fMuS7zqoXNNZGaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.18.0",
-        "eslint-visitor-keys": "^3.4.3"
+        "@typescript-eslint/types": "8.46.4",
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.4.tgz",
+      "integrity": "sha512-nPiRSKuvtTN+no/2N1kt2tUh/HoFzeEgOm9fQ6XQk4/ApGqjx0zFIIaLJ6wooR1HIoozvj2j6vTi/1fgAz7UYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.46.4",
+        "@typescript-eslint/types": "^8.46.4",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -1585,6 +1616,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.4.tgz",
+      "integrity": "sha512-+/XqaZPIAk6Cjg7NWgSGe27X4zMGqrFqZ8atJsX3CWxH/jACqWnrWI68h7nHQld0y+k9eTTjb9r+KU4twLoo9A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
@@ -1653,13 +1701,13 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
-      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.4.tgz",
+      "integrity": "sha512-USjyxm3gQEePdUwJBFjjGNG18xY9A2grDVGuk7/9AkjIF1L+ZrVnwR5VAU5JXtUnBL/Nwt3H31KlRDaksnM7/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1667,63 +1715,63 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
-      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.4.tgz",
+      "integrity": "sha512-7oV2qEOr1d4NWNmpXLR35LvCfOkTNymY9oyW+lUHkmCno7aOmIf/hMaydnJBUTBMRCOGZh8YjkFOc8dadEoNGA==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0",
+        "@typescript-eslint/project-service": "8.46.4",
+        "@typescript-eslint/tsconfig-utils": "8.46.4",
+        "@typescript-eslint/types": "8.46.4",
+        "@typescript-eslint/visitor-keys": "8.46.4",
         "debug": "^4.3.4",
-        "globby": "^11.1.0",
+        "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
-      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.4.tgz",
+      "integrity": "sha512-/++5CYLQqsO9HFGLI7APrxBJYo+5OCMpViuhV8q5/Qa3o5mMrF//eQHks+PXcsAVaLdn817fMuS7zqoXNNZGaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.18.0",
-        "eslint-visitor-keys": "^3.4.3"
+        "@typescript-eslint/types": "8.46.4",
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || >=20.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/ts-api-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=16"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
-      "peerDependencies": {
-        "typescript": ">=4.2.0"
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -2102,16 +2150,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2196,9 +2234,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2528,19 +2566,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2824,9 +2849,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3222,9 +3247,9 @@
       }
     },
     "node_modules/flat-cache/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3309,14 +3334,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -3525,27 +3551,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3944,9 +3949,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4577,16 +4582,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -5256,16 +5251,6 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
-    "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/slice-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
@@ -5565,6 +5550,54 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tinypool": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
@@ -5791,15 +5824,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
-      "integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
         "postcss": "^8.5.3",
-        "rollup": "^4.30.1"
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -5883,6 +5919,37 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.20.0",
+    "@anthropic-ai/sdk": "^0.69.0",
     "commander": "^13.1.0",
     "js-tiktoken": "^1.0.19",
     "picocolors": "^1.1.0",
@@ -52,7 +52,7 @@
     "@typescript-eslint/eslint-plugin": "^8.27.0",
     "@typescript-eslint/parser": "^8.27.0",
     "eslint": "^8.56.0",
-    "rimraf": "^5.0.5",
+    "rimraf": "^6.1.0",
     "typescript": "^5.3.3",
     "vitest": "^3.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "rimraf lib && tsc -p tsconfig.json --sourceMap --declaration",
     "lint": "eslint src --ext .ts",
+    "format": "eslint --fix src --ext .ts",
     "test": "echo 'No tests yet' && exit 0",
     "prepublishOnly": "npm run lint && npm run build"
   },
@@ -49,7 +50,7 @@
   "devDependencies": {
     "@types/node": "^20.11.5",
     "@typescript-eslint/eslint-plugin": "^8.27.0",
-    "@typescript-eslint/parser": "^7.14.0",
+    "@typescript-eslint/parser": "^8.27.0",
     "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
     "typescript": "^5.3.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { rulesGenerate } from './rulesGenerate.js';
 export const run = async (): Promise<void> => {
   try {
     const program = new Command();
-    
+
     program
       .description('Rulefy - Transform GitHub repositories into cursor rules instructions')
       .argument('[repo-path]', 'Path to the repository', '.')
@@ -35,31 +35,31 @@ export const run = async (): Promise<void> => {
     // Find the repository path (first argument that doesn't start with --)
     const repoPathIndex = args.findIndex(arg => !arg.startsWith('--'));
     const repoPath = repoPathIndex >= 0 ? args[repoPathIndex] : '.';
-    
+
     console.log(pc.bold(`\n🧩 Rulefy - Generating cursor rules for ${repoPath}\n`));
-    
+
     if (options.description) {
       console.log(pc.cyan(`Rulefying with description: "${options.description}"\n`));
     }
-    
+
     // Create a dictionary for additional options
     const additionalOptions: Record<string, string> = {};
-    
+
     // Known options already handled by Commander
     const knownOptions = ['provider', 'description', 'rule-type', 'chunk-size'];
     const knownOptionFlags = knownOptions.map(opt => `--${opt}`);
-    
+
     // Parse additional options from args array
     for (let i = 0; i < args.length; i++) {
       const arg = args[i];
-      
+
       // Skip the repository path
       if (i === repoPathIndex) continue;
-      
+
       // Check if it's an option (starts with --)
       if (arg.startsWith('--') && !knownOptionFlags.includes(arg)) {
         const optionName = arg.slice(2); // Remove '--'
-        
+
         // Check if next argument exists and doesn't start with -- and isn't the repo path
         if (i + 1 < args.length && !args[i + 1].startsWith('--') && i + 1 !== repoPathIndex) {
           additionalOptions[optionName] = args[i + 1];
@@ -70,7 +70,7 @@ export const run = async (): Promise<void> => {
         }
       }
     }
-    
+
     await rulesGenerate(repoPath, {
       description: options.description,
       ruleType: options.ruleType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,20 @@ export const run = async (): Promise<void> => {
       .description('Rulefy - Transform GitHub repositories into cursor rules instructions')
       .argument('[repo-path]', 'Path to the repository', '.')
       .allowExcessArguments(true)
-      .option('--provider <provider>', 'LLM model to use (default: "claude-sonnet-3.7-latest")')
+      .option('--provider <provider>', 'LLM model to use', 'claude-3-7-sonnet-latest')
       .option('--description <text>', 'Description of what should be rulefied')
       .option('--rule-type <type>', 'Type of rule to generate (auto, manual, agent, always)')
-      .option('--chunk-size <size>', 'Chunk size for the repository to be processed in one go (default: 100000)', '100000')
+      .option(
+        '--chunk-size <size>',
+        'Chunk size for the repository to be processed in one go',
+        (value: string) => {
+          const num = Number.parseInt(value);
+          if (Number.isNaN(num) || num <= 0)
+            throw new Error(`Invalid chunk size "${value}". Please provide a positive integer.`);
+          return num;
+        },
+        100000
+      )
       .allowUnknownOption(true);
 
     program.parse(process.argv);
@@ -36,7 +46,7 @@ export const run = async (): Promise<void> => {
     const additionalOptions: Record<string, string> = {};
     
     // Known options already handled by Commander
-    const knownOptions = ['provider', 'description', 'rule-type'];
+    const knownOptions = ['provider', 'description', 'rule-type', 'chunk-size'];
     const knownOptionFlags = knownOptions.map(opt => `--${opt}`);
     
     // Parse additional options from args array

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export const run = async (): Promise<void> => {
       .option('--provider <provider>', 'LLM model to use', 'claude-3-7-sonnet-latest')
       .option('--description <text>', 'Description of what should be rulefied')
       .option('--rule-type <type>', 'Type of rule to generate (auto, manual, agent, always)')
+      .option('--tokenizer <tokenizer>', 'Tokenizer used to count tokens', 'p50k_base')
       .option(
         '--chunk-size <size>',
         'Chunk size for the repository to be processed in one go',
@@ -46,7 +47,7 @@ export const run = async (): Promise<void> => {
     const additionalOptions: Record<string, string> = {};
 
     // Known options already handled by Commander
-    const knownOptions = ['provider', 'description', 'rule-type', 'chunk-size'];
+    const knownOptions = ['provider', 'description', 'rule-type', 'chunk-size', 'tokenizer'];
     const knownOptionFlags = knownOptions.map(opt => `--${opt}`);
 
     // Parse additional options from args array
@@ -76,6 +77,7 @@ export const run = async (): Promise<void> => {
       ruleType: options.ruleType,
       provider: options.provider,
       chunkSize: options.chunkSize,
+      tokenizer: options.tokenizer,
       additionalOptions
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export const run = async (): Promise<void> => {
       .description('Rulefy - Transform GitHub repositories into cursor rules instructions')
       .argument('[repo-path]', 'Path to the repository', '.')
       .allowExcessArguments(true)
-      .option('--provider <provider>', 'LLM model to use', 'claude-3-7-sonnet-latest')
+      .option('--provider <provider>', 'LLM model to use', 'claude-sonnet-4-5-20250929')
       .option('--description <text>', 'Description of what should be rulefied')
       .option('--rule-type <type>', 'Type of rule to generate (auto, manual, agent, always)')
       .option('--tokenizer <tokenizer>', 'Tokenizer used to count tokens', 'p50k_base')

--- a/src/llmGenerator.ts
+++ b/src/llmGenerator.ts
@@ -23,7 +23,7 @@ export async function generateWithLLM(
     console.log('Using mock response for testing');
     return generateMockResponse(repoContent);
   }
-  
+
   return await generateWithClaude(
     repoContent,
     guidelines,
@@ -42,11 +42,11 @@ function progressBar(current: number, total: number, length = 30): string {
   const percentage = current / total;
   const filledLength = Math.round(length * percentage);
   const emptyLength = length - filledLength;
-  
+
   const filled = '█'.repeat(filledLength);
   const empty = '░'.repeat(emptyLength);
   const percentageText = Math.round(percentage * 100).toString().padStart(3);
-  
+
   return `${filled}${empty} ${percentageText}%`;
 }
 
@@ -62,7 +62,7 @@ function formatTokenCount(count: number): string {
  */
 function calculateChunkCount(totalTokens: number, chunkSize: number): number {
   if (totalTokens <= chunkSize) return 1;
-  
+
   return Math.ceil(totalTokens / chunkSize);
 }
 
@@ -78,27 +78,27 @@ async function* chunkIterator(text: string, chunkSize: number): AsyncGenerator<{
   console.log(pc.cyan('\n┌─────────────────────────────────────────┐'));
   console.log(pc.cyan('│           CONTENT CHUNKING               │'));
   console.log(pc.cyan('└─────────────────────────────────────────┘\n'));
-  
+
   // Get tokenizer for the model
   const encoding = getEncoding('cl100k_base');
-  
+
   const tokens = encoding.encode(text);
   const totalTokens = tokens.length;
-  
+
   console.log(`● Document size: ${formatTokenCount(totalTokens)} tokens`);
-  
+
   console.log(`● Chunk size: ${formatTokenCount(chunkSize)} tokens`);
   // Calculate and display the estimated cost
   const estimatedCost = (totalTokens * costPerToken).toFixed(4);
   console.log(pc.yellow(`● Estimated input processing cost: $${estimatedCost} (${formatTokenCount(totalTokens)} tokens × $${costPerToken} per token)`));
-  
+
   // Create a user dialog to confirm proceeding
   const rl = readline.createInterface({ input, output });
-  
+
   try {
     const answer = await rl.question(pc.yellow('\nProceed with processing? (y/n): '));
     const proceed = answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
-    
+
     if (!proceed) {
       console.log(pc.red('\nOperation cancelled by user.'));
       process.exit(0);
@@ -110,17 +110,17 @@ async function* chunkIterator(text: string, chunkSize: number): AsyncGenerator<{
   // Calculate the total number of chunks for progress reporting
   const totalChunks = calculateChunkCount(totalTokens, chunkSize);
   console.log(pc.green(`✓ Will process ${totalChunks} chunks\n`));
-  
+
   // Yield chunks one at a time
   let i = 0;
   let chunkIndex = 0;
-  
+
   while (i < tokens.length) {
     // Get the current chunk of tokens
     const nextIndex = Math.min(i + chunkSize, tokens.length);
     const chunkTokens = tokens.slice(i, nextIndex);
     const chunk = encoding.decode(chunkTokens);
-    
+
     // Yield the current chunk along with its metadata
     yield {
       chunk,
@@ -128,12 +128,12 @@ async function* chunkIterator(text: string, chunkSize: number): AsyncGenerator<{
       tokenCount: chunkTokens.length,
       totalChunks
     };
-    
+
     // Move forward to the next chunk (no overlap)
     i = nextIndex;
     chunkIndex++;
   }
-  
+
   process.stdout.write('\n\n');
 }
 
@@ -143,14 +143,14 @@ async function generateWithClaude(repoContent: string, guidelines: string, outpu
   if (!apiKey) {
     throw new Error('ANTHROPIC_API_KEY environment variable is not set. Please set it to use Claude.');
   }
-  
+
   const client = new Anthropic({
     apiKey,
   });
 
   // Process text chunk by chunk using the iterator
   let currentSummary = ''; // This will store our progressively built summary
-  
+
   // Helper function to extract content between <cursorrules> tags
   function extractCursorrules(text: string): string {
     const regex = /<cursorrules>([\s\S]*?)<\/cursorrules>/;
@@ -160,25 +160,25 @@ async function generateWithClaude(repoContent: string, guidelines: string, outpu
     }
     return match[1].trim();
   }
-  
+
   // Create a chunk iterator to process one chunk at a time
   const chunkGen = chunkIterator(repoContent, chunkSize);
-  
+
   for await (const { chunk, index, tokenCount, totalChunks } of chunkGen) {
     const chunkDisplay = `[${index+1}/${totalChunks}]`;
     console.log(`${pc.yellow('⟳')} Processing chunk ${pc.yellow(chunkDisplay)} ${progressBar(index+1, totalChunks)}`);
-    
-    // Display chunk information 
+
+    // Display chunk information
     console.log(pc.cyan(`┌${'─'.repeat(58)}┐`));
     console.log(pc.cyan(`│ Chunk: ${String(index+1).padEnd(10)} Token Count: ${formatTokenCount(tokenCount).padEnd(12)} │`));
     console.log(pc.cyan(`└${'─'.repeat(58)}┘\n`));
-    
+
     const isFirstChunk = index === 0;
-    
+
     const systemPrompt = 'You are an expert AI system designed to analyze code repositories and generate Cursor AI rules. Your task is to create a .cursorrules file based on the provided repository content and guidelines.';
-    
+
     let userPrompt;
-    
+
     if (isFirstChunk) {
       // For the first chunk, start creating the rules
       userPrompt = `I need your help to create a Cursor rule (.cursorrules) file for my project. Please follow this process:
@@ -274,7 +274,7 @@ Be concise - the final cursorrules file text must be not more than one page long
     }
 
     process.stdout.write(`${pc.blue('🔄')} Sending to Claude ${provider}... `);
-    
+
     try {
       const startTime = Date.now();
       const response = await client.messages.create({
@@ -291,9 +291,9 @@ Be concise - the final cursorrules file text must be not more than one page long
       currentSummary = response.content[0].text;
       const endTime = Date.now();
       const processingTime = ((endTime - startTime) / 1000).toFixed(2);
-      
+
       process.stdout.write(pc.green('✓\n'));
-      
+
       // Save intermediate output to file in the specified directory
       const intermediateFileName = path.join(outputDir, `cursorrules_chunk_${index+1}_of_${totalChunks}.md`);
       await fs.writeFile(intermediateFileName, currentSummary);
@@ -306,11 +306,11 @@ Be concise - the final cursorrules file text must be not more than one page long
       throw new Error(`${pc.red('Unknown error occurred while generating with Claude on chunk')} ${index+1}`);
     }
   }
-  
+
   console.log(pc.green('\n┌─────────────────────────────────────────┐'));
   console.log(pc.green('│          PROCESSING COMPLETE            │'));
   console.log(pc.green('└─────────────────────────────────────────┘\n'));
-  
+
   // Only extract the cursorrules content at the very end
   return extractCursorrules(currentSummary);
 }
@@ -319,7 +319,7 @@ function generateMockResponse(repoContent: string): string {
   // Extract some information from the repo content for the mock response
   const repoLines = repoContent.split('\n');
   const repoName = repoLines.find(line => line.includes('# Project:'))?.replace('# Project:', '').trim() || 'Repository';
-  
+
   return `# .cursorrules for ${repoName}
 
 ## Project Overview

--- a/src/llmGenerator.ts
+++ b/src/llmGenerator.ts
@@ -1,5 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
-import { getEncoding } from 'js-tiktoken';
+import { getEncoding, TiktokenEncoding } from 'js-tiktoken';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import pc from 'picocolors';
@@ -14,6 +14,7 @@ export async function generateWithLLM(
   outputDir: string,
   provider: string,
   chunkSize: number,
+  tokenizer: string,
   description?: string,
   ruleType?: string,
 ): Promise<string> {
@@ -30,6 +31,7 @@ export async function generateWithLLM(
     outputDir,
     provider,
     chunkSize,
+    tokenizer,
     description,
     ruleType,
   );
@@ -69,7 +71,7 @@ function calculateChunkCount(totalTokens: number, chunkSize: number): number {
 /**
  * Iterator that yields one chunk at a time to save memory
  */
-async function* chunkIterator(text: string, chunkSize: number): AsyncGenerator<{
+async function* chunkIterator(text: string, chunkSize: number, tokenizer: string): AsyncGenerator<{
   chunk: string;
   index: number;
   tokenCount: number;
@@ -80,7 +82,7 @@ async function* chunkIterator(text: string, chunkSize: number): AsyncGenerator<{
   console.log(pc.cyan('└─────────────────────────────────────────┘\n'));
 
   // Get tokenizer for the model
-  const encoding = getEncoding('cl100k_base');
+  const encoding = getEncoding(tokenizer as TiktokenEncoding);
 
   const tokens = encoding.encode(text);
   const totalTokens = tokens.length;
@@ -137,7 +139,7 @@ async function* chunkIterator(text: string, chunkSize: number): AsyncGenerator<{
   process.stdout.write('\n\n');
 }
 
-async function generateWithClaude(repoContent: string, guidelines: string, outputDir: string, provider: string, chunkSize: number, description?: string, ruleType?: string): Promise<string> {
+async function generateWithClaude(repoContent: string, guidelines: string, outputDir: string, provider: string, chunkSize: number, tokenizer: string, description?: string, ruleType?: string): Promise<string> {
   // Check for API key in environment
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
@@ -162,7 +164,7 @@ async function generateWithClaude(repoContent: string, guidelines: string, outpu
   }
 
   // Create a chunk iterator to process one chunk at a time
-  const chunkGen = chunkIterator(repoContent, chunkSize);
+  const chunkGen = chunkIterator(repoContent, chunkSize, tokenizer);
 
   for await (const { chunk, index, tokenCount, totalChunks } of chunkGen) {
     const chunkDisplay = `[${index+1}/${totalChunks}]`;

--- a/src/llmGenerator.ts
+++ b/src/llmGenerator.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
+import { Message } from '@anthropic-ai/sdk/resources';
 import { getEncoding, TiktokenEncoding } from 'js-tiktoken';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -78,7 +79,7 @@ async function* chunkIterator(text: string, chunkSize: number, tokenizer: string
   totalChunks: number;
 }, void, unknown> {
   console.log(pc.cyan('\n┌─────────────────────────────────────────┐'));
-  console.log(pc.cyan('│           CONTENT CHUNKING               │'));
+  console.log(pc.cyan('│           CONTENT CHUNKING              │'));
   console.log(pc.cyan('└─────────────────────────────────────────┘\n'));
 
   // Get tokenizer for the model
@@ -172,7 +173,7 @@ async function generateWithClaude(repoContent: string, guidelines: string, outpu
 
     // Display chunk information
     console.log(pc.cyan(`┌${'─'.repeat(58)}┐`));
-    console.log(pc.cyan(`│ Chunk: ${String(index+1).padEnd(10)} Token Count: ${formatTokenCount(tokenCount).padEnd(12)} │`));
+    console.log(pc.cyan(`│ Chunk: ${String(index+1).padEnd(10)} Token Count: ${formatTokenCount(tokenCount).padEnd(35)} │`));
     console.log(pc.cyan(`└${'─'.repeat(58)}┘\n`));
 
     const isFirstChunk = index === 0;
@@ -276,25 +277,13 @@ Be concise - the final cursorrules file text must be not more than one page long
     }
 
     process.stdout.write(`${pc.blue('🔄')} Sending to Claude ${provider}... `);
-
     try {
       const startTime = Date.now();
-      const response = await client.messages.create({
-        model: provider,
-        max_tokens: 8000,
-        system: systemPrompt,
-        messages: [
-          {
-            role: 'user',
-            content: userPrompt
-          }
-        ]
-      });
-      currentSummary = response.content[0].text;
+      const response = await callClaudeWithRetry(client, provider, systemPrompt, userPrompt);
+      currentSummary = response.content[0].type === 'text' ? response.content[0].text : '';
       const endTime = Date.now();
       const processingTime = ((endTime - startTime) / 1000).toFixed(2);
-
-      process.stdout.write(pc.green('✓\n'));
+      process.stdout.write(pc.green(`✓ ${response.usage.input_tokens} input tokens\n`));
 
       // Save intermediate output to file in the specified directory
       const intermediateFileName = path.join(outputDir, `cursorrules_chunk_${index+1}_of_${totalChunks}.md`);
@@ -315,6 +304,30 @@ Be concise - the final cursorrules file text must be not more than one page long
 
   // Only extract the cursorrules content at the very end
   return extractCursorrules(currentSummary);
+}
+
+async function callClaudeWithRetry(client: Anthropic, provider: string, systemPrompt: string, userPrompt: string, retriesRemaining: number = 3): Promise<Message> {
+  const response = await client.messages.create({
+    model: provider,
+    max_tokens: 8000,
+    system: systemPrompt,
+    messages: [
+      {
+        role: 'user',
+        content: userPrompt
+      }
+    ]
+  })
+    .catch(async (error: typeof Anthropic.APIError) => {
+      if (error instanceof Anthropic.RateLimitError && retriesRemaining > 0) {
+        const waitTime = Number.parseInt(error.headers.get('retry-after') || '60');
+        console.log(pc.yellow(`Rate limit exceeded. Waiting for ${waitTime} seconds and retrying...`));
+        await new Promise(resolve => setTimeout(resolve, waitTime * 1000 ));
+        return await callClaudeWithRetry(client, provider, systemPrompt, userPrompt, retriesRemaining - 1);
+      }
+      throw new Error(`${pc.red('Error generating with Claude')}`, {cause: error});
+    });
+  return response;
 }
 
 function generateMockResponse(repoContent: string): string {

--- a/src/llmGenerator.ts
+++ b/src/llmGenerator.ts
@@ -6,18 +6,16 @@ import pc from 'picocolors';
 import readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 
-// Environment variables for chunk configuration, with defaults
-const CHUNK_SIZE = Number(process.env.CHUNK_SIZE || '100000');
 const costPerToken = 3e-6; // 3$ per million tokens
 
 export async function generateWithLLM(
   repoContent: string,
   guidelines: string,
-  outputDir: string = '.',
+  outputDir: string,
+  provider: string,
+  chunkSize: number,
   description?: string,
   ruleType?: string,
-  provider: string = 'claude-3-7-sonnet-latest',
-  chunkSize: number = CHUNK_SIZE,
 ): Promise<string> {
   // If this is a test run with dummy API key, just return a mock response
   const apiKey = process.env.ANTHROPIC_API_KEY;
@@ -26,7 +24,15 @@ export async function generateWithLLM(
     return generateMockResponse(repoContent);
   }
   
-  return await generateWithClaude(repoContent, guidelines, outputDir, description, ruleType, provider, chunkSize);
+  return await generateWithClaude(
+    repoContent,
+    guidelines,
+    outputDir,
+    provider,
+    chunkSize,
+    description,
+    ruleType,
+  );
 }
 
 /**
@@ -63,7 +69,7 @@ function calculateChunkCount(totalTokens: number, chunkSize: number): number {
 /**
  * Iterator that yields one chunk at a time to save memory
  */
-async function* chunkIterator(text: string, chunkSize?: number): AsyncGenerator<{
+async function* chunkIterator(text: string, chunkSize: number): AsyncGenerator<{
   chunk: string;
   index: number;
   tokenCount: number;
@@ -78,11 +84,10 @@ async function* chunkIterator(text: string, chunkSize?: number): AsyncGenerator<
   
   const tokens = encoding.encode(text);
   const totalTokens = tokens.length;
-  const cSize = chunkSize || CHUNK_SIZE;
   
   console.log(`● Document size: ${formatTokenCount(totalTokens)} tokens`);
-  console.log(`● Chunk size: ${formatTokenCount(cSize)} tokens`);
   
+  console.log(`● Chunk size: ${formatTokenCount(chunkSize)} tokens`);
   // Calculate and display the estimated cost
   const estimatedCost = (totalTokens * costPerToken).toFixed(4);
   console.log(pc.yellow(`● Estimated input processing cost: $${estimatedCost} (${formatTokenCount(totalTokens)} tokens × $${costPerToken} per token)`));
@@ -101,9 +106,9 @@ async function* chunkIterator(text: string, chunkSize?: number): AsyncGenerator<
   } finally {
     rl.close();
   }
-  
+
   // Calculate the total number of chunks for progress reporting
-  const totalChunks = calculateChunkCount(totalTokens, chunkSize || CHUNK_SIZE);
+  const totalChunks = calculateChunkCount(totalTokens, chunkSize);
   console.log(pc.green(`✓ Will process ${totalChunks} chunks\n`));
   
   // Yield chunks one at a time
@@ -112,7 +117,8 @@ async function* chunkIterator(text: string, chunkSize?: number): AsyncGenerator<
   
   while (i < tokens.length) {
     // Get the current chunk of tokens
-    const chunkTokens = tokens.slice(i, Math.min(i + cSize, tokens.length));
+    const nextIndex = Math.min(i + chunkSize, tokens.length);
+    const chunkTokens = tokens.slice(i, nextIndex);
     const chunk = encoding.decode(chunkTokens);
     
     // Yield the current chunk along with its metadata
@@ -124,14 +130,14 @@ async function* chunkIterator(text: string, chunkSize?: number): AsyncGenerator<
     };
     
     // Move forward to the next chunk (no overlap)
-    i += cSize;
+    i = nextIndex;
     chunkIndex++;
   }
   
   process.stdout.write('\n\n');
 }
 
-async function generateWithClaude(repoContent: string, guidelines: string, outputDir: string = '.', description?: string, ruleType?: string, provider: string = 'claude-3-7-sonnet-latest', chunkSize?: number): Promise<string> {
+async function generateWithClaude(repoContent: string, guidelines: string, outputDir: string, provider: string, chunkSize: number, description?: string, ruleType?: string): Promise<string> {
   // Check for API key in environment
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {

--- a/src/rulesGenerate.ts
+++ b/src/rulesGenerate.ts
@@ -20,14 +20,14 @@ export async function rulesGenerate(
   try {
     // 1. Extract repo name from URL or path
     const repoName = extractRepoName(repoPath);
-    
+
     // 2. Set output directory based on repo name
     const outputDir = `${repoName}-output`;
     const outputFile = path.join(outputDir, `${repoName}.rules.mdc`);
-    
+
     // Ensure output directory exists
     await fs.mkdir(outputDir, { recursive: true });
-    
+
     console.log(pc.cyan('1. Converting repository to text using repomix...'));
     // 3. Run repomix to get repo representation
     let repoText: string;
@@ -37,7 +37,7 @@ export async function rulesGenerate(
       console.log(pc.yellow(`Warning: Could not get actual repo content. Error: ${error}. Using mock content for testing.`));
       repoText = generateMockRepoContent(repoName);
     }
-    
+
     console.log(pc.cyan('2. Reading cursor rules guidelines...'));
     // 4. Read guidelines file
     let guidelinesText: string;
@@ -46,7 +46,7 @@ export async function rulesGenerate(
       const modulePath = new URL(import.meta.url).pathname;
       const moduleDir = path.dirname(modulePath);
       const moduleDirPath = path.resolve(moduleDir, '../src/prompts/cursor_mdc.md');
-      
+
       guidelinesText = await fs.readFile(moduleDirPath, 'utf-8');
       console.log(pc.green('✓ Successfully read guidelines from module path'));
     } catch (_error) {
@@ -60,7 +60,7 @@ export async function rulesGenerate(
         guidelinesText = generateMockGuidelines();
       }
     }
-    
+
     console.log(pc.cyan('3. Generating cursor rules...'));
     // 5. Generate rules using LLM
     const generatedRules = await generateWithLLM(
@@ -72,11 +72,11 @@ export async function rulesGenerate(
       options.description,
       options.ruleType,
     );
-    
+
     console.log(pc.cyan(`4. Writing rules to ${outputFile}...`));
     // 6. Write output to file
     await fs.writeFile(outputFile, generatedRules);
-    
+
     console.log(pc.green(`\n✅ Successfully generated cursor rules for ${repoName}!`));
     console.log(`Output saved to: ${pc.bold(outputFile)}`);
     console.log(`All generated files are in: ${pc.bold(outputDir)}`);
@@ -93,7 +93,7 @@ function extractRepoName(repoPath: string): string {
   if (repoPath === '.') {
     return path.basename(process.cwd());
   }
-  
+
   // For local paths, use the directory name
   try {
     // Sync version to avoid Promise handling in this synchronous function
@@ -104,28 +104,28 @@ function extractRepoName(repoPath: string): string {
     // Path doesn't exist or can't be accessed, check if it's a remote repo
     console.log(pc.yellow(`Warning: Could not find a local repo by path: ${repoPath}. Error: ${_e}`));
   }
-  
+
   // Handle format like 'owner/repo'
   if (/^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+$/.test(repoPath)) {
     return repoPath.split('/')[1];
   }
-  
+
   // Handle GitHub URLs (only http or https)
   const githubUrlMatch = repoPath.match(/^https?:\/\/github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)/);
   if (githubUrlMatch) {
     return githubUrlMatch[2];
   }
-  
+
   // If no match, use a sanitized version of the path as fallback
   return repoPath.replace(/[^a-zA-Z0-9_-]/g, '-').replace(/^-+|-+$/g, '');
 }
 
 async function runRepomix(repoPath: string, outputDir: string, additionalOptions?: Record<string, string>): Promise<string> {
   try {
-    
+
     // Build repomix command based on whether it's a remote or local repository
     let command = `npx repomix ${repoPath}`;
-    
+
     // Add any additional options to the command
     if (additionalOptions) {
       for (const [key, value] of Object.entries(additionalOptions)) {
@@ -136,23 +136,23 @@ async function runRepomix(repoPath: string, outputDir: string, additionalOptions
         }
       }
     }
-    
+
     // Add output directory to command
     const outputFilePath = path.join(outputDir, 'repomix-output');
     command += ` --output "${outputFilePath}"`;
-    
+
     // Display the command being executed
     console.log(pc.cyan(`Executing: ${command}`));
-    
+
     // Run repomix command
-    execSync(command, { 
+    execSync(command, {
       encoding: 'utf-8',
       stdio: 'inherit' // Show all output directly in the console
     });
-    
+
     // Read the content of the generated file
     console.log(pc.green(`Reading repomix output from: ${outputFilePath}`));
-    
+
     const content = await fs.readFile(outputFilePath, 'utf-8');
     return content;
   } catch (error) {

--- a/src/rulesGenerate.ts
+++ b/src/rulesGenerate.ts
@@ -8,8 +8,8 @@ import { generateWithLLM } from './llmGenerator.js';
 interface RulesGenerateOptions {
   description?: string;
   ruleType?: string;
-  provider?: string;
-  chunkSize?: number;
+  provider: string;
+  chunkSize: number;
   additionalOptions?: Record<string, string>;
 }
 
@@ -64,13 +64,13 @@ export async function rulesGenerate(
     console.log(pc.cyan('3. Generating cursor rules...'));
     // 5. Generate rules using LLM
     const generatedRules = await generateWithLLM(
-      repoText, 
-      guidelinesText, 
-      outputDir, 
+      repoText,
+      guidelinesText,
+      outputDir,
+      options.provider,
+      options.chunkSize,
       options.description,
       options.ruleType,
-      options.provider,
-      options.chunkSize
     );
     
     console.log(pc.cyan(`4. Writing rules to ${outputFile}...`));

--- a/src/rulesGenerate.ts
+++ b/src/rulesGenerate.ts
@@ -10,6 +10,7 @@ interface RulesGenerateOptions {
   ruleType?: string;
   provider: string;
   chunkSize: number;
+  tokenizer: string;
   additionalOptions?: Record<string, string>;
 }
 
@@ -32,7 +33,7 @@ export async function rulesGenerate(
     // 3. Run repomix to get repo representation
     let repoText: string;
     try {
-      repoText = await runRepomix(repoPath, outputDir, options.additionalOptions);
+      repoText = await runRepomix(repoPath, outputDir, options.tokenizer, options.additionalOptions);
     } catch (error) {
       console.log(pc.yellow(`Warning: Could not get actual repo content. Error: ${error}. Using mock content for testing.`));
       repoText = generateMockRepoContent(repoName);
@@ -69,6 +70,7 @@ export async function rulesGenerate(
       outputDir,
       options.provider,
       options.chunkSize,
+      options.tokenizer,
       options.description,
       options.ruleType,
     );
@@ -120,11 +122,11 @@ function extractRepoName(repoPath: string): string {
   return repoPath.replace(/[^a-zA-Z0-9_-]/g, '-').replace(/^-+|-+$/g, '');
 }
 
-async function runRepomix(repoPath: string, outputDir: string, additionalOptions?: Record<string, string>): Promise<string> {
+async function runRepomix(repoPath: string, outputDir: string, tokenizer: string, additionalOptions?: Record<string, string>): Promise<string> {
   try {
 
     // Build repomix command based on whether it's a remote or local repository
-    let command = `npx repomix ${repoPath}`;
+    let command = `npx repomix ${repoPath} --token-count-encoding ${tokenizer}`;
 
     // Add any additional options to the command
     if (additionalOptions) {


### PR DESCRIPTION
## Summary
- replace the deprecated Claude Sonnet 3.7 integration with Sonnet 4.5 and surface tokenizer stats/output tweaks from the retry work
- add resilient Claude API retry handling, better console output, and README guidance
- expose the tokenizer as a CLI option (defaulting to p50k_base) and pass it through to repomix so Anthropic-compatible limits are used end‑to‑end
- tighten CLI parsing by validating numeric chunk sizes, fixing chunk iteration, and removing stale defaults/env vars
- refresh tooling (anthropic SDK 0.69.0, rimraf 6.1.0, ESLint parser upgrade, audit fix) plus whitespace cleanup

## Details
- `feat: use claude sonnet 4.5 model` – updates the default Anthropic model, retiring Sonnet 3.7 which is now deprecated.
- `feat: implement retry logic for Claude API calls` – introduces a reusable retry helper for rate‑limit errors, prints input token counts in responses, improves console formatting, and syncs the README.
- `feat: expose tokenizer as command line option` – adds a `--tokenizer` flag, switches the default to `p50k_base`, and ensures the chosen tokenizer flows into repomix.
- `fix: argument parsing and chunk iteration` – sets a default provider, validates chunk size inputs, removes the unused `CHUNK_SIZE` env var and redundant defaults, and corrects chunk iteration logic.
- `chore: update dependencies` – bumps `@anthropic-ai/sdk` to 0.69.0, `rimraf` to 6.1.0, and freshens other dependencies for compatibility.
- `chore: upgrade eslint parser, run audit fix` – keeps linting/tooling current and resolves npm audit issues.
- `style: clean up whitespace` – normalizes blank lines/formatting across touched files.

Closes #1 